### PR TITLE
Dockerfile not creating the correct binary for the arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile used as distribution for the methodwebtest CLI in Tool container format
-FROM chromedp/headless-shell:129.0.6643.2 
+FROM alpine:3.20
 
 ARG CLI_NAME="methodwebtest"
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y ca-certificates git
+RUN apk update && apk --no-cache add ca-certificates bash git
 
 # Setup Method Directory Structure
 RUN \
@@ -17,7 +17,8 @@ RUN \
   mkdir -p /opt/method/${CLI_NAME}/service/bin && \
   mkdir -p /mnt/output
 
-COPY configs/paths/*                  /opt/method/${CLI_NAME}/var/conf/paths/
+COPY configs/*                     /opt/method/${CLI_NAME}/var/conf/
+COPY configs/paths/*               /opt/method/${CLI_NAME}/var/conf/paths/
 
 COPY ${CLI_NAME} /opt/method/${CLI_NAME}/service/bin/${CLI_NAME}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ type MethodWebTest struct {
 	VersionCmd   *cobra.Command
 }
 
-// NewMethodWebTest creates a new MethodWebTest struct with the provided version string. The Webscan struct is used throughout the
+// NewMethodWebTest creates a new MethodWebTest struct with the provided version string. The Methodwebtest struct is used throughout the
 // subcommands as a contex within which output results and configuration values can be stored.
 // We pass the version value in from the main.go file, where we set the version string during the build process.
 func NewMethodWebTest(version string) *MethodWebTest {


### PR DESCRIPTION
**Error**

```
% docker run methodwebtest:local general path -h
exec /opt/method/methodwebtest/service/bin/methodwebtest: exec format error
```


**Local command fixed issue which makes me thing it was just a bad build?**

`% GOOS=linux GOARCH=amd64 go build -o methodwebtest`
