### PR TITLE
Path Traversal Tolerance Flag 

### DIFF
--- a/cmd/apache.go
+++ b/cmd/apache.go
@@ -126,9 +126,14 @@ func (a *MethodWebTest) InitApacheCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			threshold, err := cmd.Flags().GetFloat64("threshold")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Load configuration
-			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly)
+			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold)
 
 			// Generate report
 			report := path.PerformApachePathTraversal(cmd.Context(), config)
@@ -142,6 +147,7 @@ func (a *MethodWebTest) InitApacheCommand() {
 	traversalCmd.Flags().String("responsecodes", "200-299", "Response codes to consider as valid responses")
 	traversalCmd.Flags().Bool("ignorebasecontentmatch", true, "Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect")
 	traversalCmd.Flags().Bool("successfulonly", false, "Only show successful attempts")
+	traversalCmd.Flags().Float64("threshold", 0.05, "Threshold for a negitive finding that represents the percentage difference between the size of the response body in question and the baseline response (0.0 is an exact match, with .05 being a 5 percent difference)")
 
 	pathCmd.AddCommand(traversalCmd)
 

--- a/cmd/general.go
+++ b/cmd/general.go
@@ -359,9 +359,14 @@ func (a *MethodWebTest) InitGeneralCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			threshold, err := cmd.Flags().GetFloat64("threshold")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Load configuration
-			config := LoadPathTraversalConfig(targets, paths, pathlists, queryParam, responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly)
+			config := LoadPathTraversalConfig(targets, paths, pathlists, queryParam, responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold)
 
 			// Generate report
 			report := path.PerformGeneralPathTraversal(cmd.Context(), config)
@@ -378,6 +383,7 @@ func (a *MethodWebTest) InitGeneralCommand() {
 	traversalCmd.Flags().String("responsecodes", "200-299", "Response codes to consider as valid responses")
 	traversalCmd.Flags().Bool("ignorebasecontentmatch", true, "Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect")
 	traversalCmd.Flags().Bool("successfulonly", false, "Only show successful attempts")
+	traversalCmd.Flags().Float64("threshold", 0.05, "Threshold for a negitive finding that represents the percentage difference between the size of the response body in question and the baseline response (0.0 is an exact match, with .05 being a 5 percent difference)")
 
 	pathCmd.AddCommand(traversalCmd)
 
@@ -594,7 +600,7 @@ func LoadPathCrlfConfig(targets []string, headerName string, headerValue string,
 }
 
 // LoadPathTraversalConfig loads the configuration for a path-based fuzzing run.
-func LoadPathTraversalConfig(targets, paths []string, pathlists []string, queryParam string, responseCodes string, ignoreBaseContent bool, timeout, sleep, retries int, successfulOnly bool) *methodwebtest.PathTraversalConfig {
+func LoadPathTraversalConfig(targets, paths []string, pathlists []string, queryParam string, responseCodes string, ignoreBaseContent bool, timeout, sleep, retries int, successfulOnly bool, threshold float64) *methodwebtest.PathTraversalConfig {
 	config := &methodwebtest.PathTraversalConfig{
 		Targets:           targets,
 		Paths:             paths,
@@ -605,6 +611,7 @@ func LoadPathTraversalConfig(targets, paths []string, pathlists []string, queryP
 		Sleep:             sleep,
 		Retries:           retries,
 		SuccessfulOnly:    successfulOnly,
+		Threshold:         threshold,
 	}
 	if queryParam != "" {
 		config.QueryParam = &queryParam

--- a/cmd/nginx.go
+++ b/cmd/nginx.go
@@ -144,9 +144,14 @@ func (a *MethodWebTest) InitNginxCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			threshold, err := cmd.Flags().GetFloat64("threshold")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Load configuration
-			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly)
+			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold)
 
 			// Generate report
 			report := path.PerformNginxPathTraversal(cmd.Context(), config)
@@ -160,6 +165,7 @@ func (a *MethodWebTest) InitNginxCommand() {
 	traversalCmd.Flags().String("responsecodes", "200-299", "Response codes to consider as valid responses")
 	traversalCmd.Flags().Bool("ignorebasecontentmatch", true, "Ignores valid responses with identical size and word length to the base path, typically signifying a web backend redirect")
 	traversalCmd.Flags().Bool("successfulonly", false, "Only show successful attempts")
+	traversalCmd.Flags().Float64("threshold", 0.05, "Threshold for a negitive finding that represents the percentage difference between the size of the response body in question and the baseline response (0.0 is an exact match, with .05 being a 5 percent difference)")
 
 	_ = traversalCmd.MarkFlagRequired("targets")
 

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -58,6 +58,7 @@ types:
       retries: integer
       sleep: integer
       successfulOnly: boolean
+      threshold: float
   # Query Configs
   QueryReverseProxyConfig:
     properties:

--- a/fern/definition/report.yml
+++ b/fern/definition/report.yml
@@ -36,6 +36,7 @@ types:
       retries: integer
       sleep: integer
       successfulOnly: boolean
+      threshold: optional<float>
   EngineConfig:
     union:
       InjectionEngineConfig: InjectionEngineConfig

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -373,6 +373,7 @@ type PathTraversalConfig struct {
 	Retries           int      `json:"retries" url:"retries"`
 	Sleep             int      `json:"sleep" url:"sleep"`
 	SuccessfulOnly    bool     `json:"successfulOnly" url:"successfulOnly"`
+	Threshold         float64  `json:"threshold" url:"threshold"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -716,6 +717,7 @@ type PathTraversalEngineConfig struct {
 	Retries           int      `json:"retries" url:"retries"`
 	Sleep             int      `json:"sleep" url:"sleep"`
 	SuccessfulOnly    bool     `json:"successfulOnly" url:"successfulOnly"`
+	Threshold         *float64 `json:"threshold,omitempty" url:"threshold,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage

--- a/internal/apache/path/traversal.go
+++ b/internal/apache/path/traversal.go
@@ -42,6 +42,7 @@ func PerformApachePathTraversal(ctx context.Context, config *methodwebtest.PathT
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,
 		SuccessfulOnly:    config.SuccessfulOnly,
+		Threshold:         &config.Threshold,
 	}
 	report := utils.RunPathTraversalEngine(ctx, &engineConfig)
 	report.Config = methodwebtest.NewEngineConfigFromPathTraversalEngineConfig(&engineConfig)

--- a/internal/general/path/traversal.go
+++ b/internal/general/path/traversal.go
@@ -12,16 +12,16 @@ func PerformGeneralPathTraversal(ctx context.Context, config *methodwebtest.Path
 		Targets:           config.Targets,
 		Paths:             config.Paths,
 		PathFiles:         config.PathLists,
+		QueryParam:        config.QueryParam,
 		ResponseCodes:     config.ResponseCodes,
 		IgnoreBaseContent: config.IgnoreBaseContent,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,
 		SuccessfulOnly:    config.SuccessfulOnly,
+		Threshold:         &config.Threshold,
 	}
-	if config.QueryParam != nil {
-		engineConfig.QueryParam = config.QueryParam
-	}
+
 	report := utils.RunPathTraversalEngine(ctx, &engineConfig)
 	report.Config = methodwebtest.NewEngineConfigFromPathTraversalEngineConfig(&engineConfig)
 	return report

--- a/internal/nginx/path/traversal.go
+++ b/internal/nginx/path/traversal.go
@@ -36,6 +36,7 @@ func PerformNginxPathTraversal(ctx context.Context, config *methodwebtest.PathTr
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,
 		SuccessfulOnly:    config.SuccessfulOnly,
+		Threshold:         &config.Threshold,
 	}
 	report := utils.RunPathTraversalEngine(ctx, &engineConfig)
 	report.Config = methodwebtest.NewEngineConfigFromPathTraversalEngineConfig(&engineConfig)


### PR DESCRIPTION
## Goal 

- Enable reduction of noise in file creation

## Change

- Created `threshold` flag that lets you set the `threshold` for a negative finding that represents the percentage difference between the response body in question and the baseline response (0.0 is an exact match, with .05 being a 5 percent difference)
  - 0.0 is exact match
  - 0.50 is 50% difference
  - 1.00 is 100% difference
  - 2.00 is 200% difference