### PR TITLE
Add 'maxruntime' parameter to General Path Traversal Tool

### DIFF
--- a/cmd/apache.go
+++ b/cmd/apache.go
@@ -133,7 +133,7 @@ func (a *MethodWebTest) InitApacheCommand() {
 			}
 
 			// Load configuration
-			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold)
+			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold, nil)
 
 			// Generate report
 			report := path.PerformApachePathTraversal(cmd.Context(), config)

--- a/cmd/nginx.go
+++ b/cmd/nginx.go
@@ -151,7 +151,7 @@ func (a *MethodWebTest) InitNginxCommand() {
 			}
 
 			// Load configuration
-			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold)
+			config := LoadPathTraversalConfig(targets, []string{}, []string{}, "", responseCodes, ignoreBase, timeout, sleep, retries, successfulOnly, threshold, nil)
 
 			// Generate report
 			report := path.PerformNginxPathTraversal(cmd.Context(), config)

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -59,6 +59,7 @@ types:
       sleep: integer
       successfulOnly: boolean
       threshold: float
+      maxRunTime: optional<integer>
   # Query Configs
   QueryReverseProxyConfig:
     properties:

--- a/fern/definition/report.yml
+++ b/fern/definition/report.yml
@@ -37,6 +37,7 @@ types:
       sleep: integer
       successfulOnly: boolean
       threshold: optional<float>
+      maxRunTime: optional<integer>
   EngineConfig:
     union:
       InjectionEngineConfig: InjectionEngineConfig

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -374,6 +374,7 @@ type PathTraversalConfig struct {
 	Sleep             int      `json:"sleep" url:"sleep"`
 	SuccessfulOnly    bool     `json:"successfulOnly" url:"successfulOnly"`
 	Threshold         float64  `json:"threshold" url:"threshold"`
+	MaxRunTime        *int     `json:"maxRunTime,omitempty" url:"maxRunTime,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -718,6 +719,7 @@ type PathTraversalEngineConfig struct {
 	Sleep             int      `json:"sleep" url:"sleep"`
 	SuccessfulOnly    bool     `json:"successfulOnly" url:"successfulOnly"`
 	Threshold         *float64 `json:"threshold,omitempty" url:"threshold,omitempty"`
+	MaxRunTime        *int     `json:"maxRunTime,omitempty" url:"maxRunTime,omitempty"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage

--- a/internal/general/path/traversal.go
+++ b/internal/general/path/traversal.go
@@ -2,6 +2,7 @@ package general
 
 import (
 	"context"
+	"time"
 
 	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
 	utils "github.com/Method-Security/methodwebtest/utils/engines"
@@ -20,6 +21,15 @@ func PerformGeneralPathTraversal(ctx context.Context, config *methodwebtest.Path
 		Sleep:             config.Sleep,
 		SuccessfulOnly:    config.SuccessfulOnly,
 		Threshold:         &config.Threshold,
+		MaxRunTime:        config.MaxRunTime,
+	}
+
+	// If MaxRunTime is set, create a context with a timeout
+	if config.MaxRunTime != nil && *config.MaxRunTime > 0 {
+		var cancel context.CancelFunc
+		maxTime := *config.MaxRunTime
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(maxTime)*time.Second)
+		defer cancel()
 	}
 
 	report := utils.RunPathTraversalEngine(ctx, &engineConfig)

--- a/utils/engines/pathTraversal.go
+++ b/utils/engines/pathTraversal.go
@@ -37,6 +37,12 @@ func RunPathTraversalEngine(ctx context.Context, config *methodwebtest.PathTrave
 
 	var targets []*methodwebtest.TargetInfo
 	for _, target := range config.Targets {
+		// Check if context has expired
+		if ctx.Err() != nil {
+			report.Errors = append(report.Errors, "Path traversal engine timeout exceeded")
+			break
+		}
+
 		targetInfo := methodwebtest.TargetInfo{Target: target, StartTimestamp: time.Now()}
 
 		// Get baseline size and word count
@@ -56,6 +62,12 @@ func RunPathTraversalEngine(ctx context.Context, config *methodwebtest.PathTrave
 		var attempts []*methodwebtest.AttemptInfo
 		for _, injectionPath := range allPaths {
 			for i := 0; i <= config.Retries; i++ {
+				// Check if context has expired
+				if ctx.Err() != nil {
+					report.Errors = append(report.Errors, "Path traversal engine timeout exceeded")
+					break
+				}
+
 				attemptInfo := methodwebtest.AttemptInfo{}
 
 				// Path injection location


### PR DESCRIPTION
## Update

- Added 'maxruntime' parameter
- When timesout it will return the data that has been gathered up until that point while also returning an error that says "PathTraversal timedout"