### PR TITLE
WordPress XMLRPC No Auth Functions

### DIFF
--- a/cmd/wordpress.go
+++ b/cmd/wordpress.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	body "github.com/Method-Security/methodwebtest/internal/wordpress/body/xmlrpc"
 	path "github.com/Method-Security/methodwebtest/internal/wordpress/path"
 	"github.com/spf13/cobra"
 )
@@ -103,5 +105,91 @@ func (a *MethodWebTest) InitWordpressCommand() {
 
 	wordpressCmd.AddCommand(pathCmd)
 
+	// pathCmd holds the subcommands for path injection tests
+	bodyCmd := &cobra.Command{
+		Use:   "body",
+		Short: "Perform body injection tests against a target",
+		Long:  `Perform body injection tests against a target`,
+	}
+
+	xmlrpcCmd := &cobra.Command{
+		Use:   "xmlrpc",
+		Short: "Perform xmlrpc injection tests against a target",
+		Long:  `Perform xmlrpc injection tests against a target`,
+	}
+
+	functionAuthCmd := &cobra.Command{
+		Use:   "functionauth",
+		Short: "Perform xmlrpc function authentication injection tests against a target",
+		Long:  `Perform xmlrpc function authentication injection tests against a target`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Target flags
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(targets) == 0 {
+				a.OutputSignal.AddError(errors.New("no targets provided"))
+				return
+			}
+
+			// Configuration flags
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			retries, err := cmd.Flags().GetInt("retries")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Load configuration
+			config := LoadBodyXMLRPCFunctionAuthConfig(targets, timeout, retries, sleep)
+
+			// Generate report
+			report := body.PerformBodyXMLRPCFunctionAuthInjection(cmd.Context(), config)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+	xmlrpcCmd.AddCommand(functionAuthCmd)
+
+	bodyCmd.AddCommand(xmlrpcCmd)
+
+	wordpressCmd.AddCommand(bodyCmd)
+
 	a.RootCmd.AddCommand(wordpressCmd)
+}
+
+func LoadBodyXMLRPCFunctionAuthConfig(targets []string, timeout int, retries int, sleep int) *methodwebtest.BodyXmlRpcFunctionAuthConfig {
+	config := &methodwebtest.BodyXmlRpcFunctionAuthConfig{
+		Targets: targets,
+		Timeout: timeout,
+		Retries: retries,
+		Sleep:   sleep,
+	}
+
+	if config.Timeout < 1 {
+		config.Timeout = 0
+	}
+	if config.Retries < 0 {
+		config.Retries = 0
+	}
+	if config.Sleep < 0 {
+		config.Sleep = 0
+	}
+
+	return config
 }

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -68,6 +68,13 @@ types:
       timeout: integer
       retries: integer
       sleep: integer
+  # Body Configs
+  BodyXmlRpcFunctionAuthConfig:
+    properties:
+      targets: list<string>
+      timeout: integer
+      retries: integer
+      sleep: integer
   # Multi Injection Configs
   InjectionLocation:
     enum:

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -27,6 +27,9 @@ types:
   QueryEvent:
     enum:
       - REDIRECT
+  BodyEvent:
+    enum:
+      - XMLRPCFUNCTIONAUTH
   MultiEvent:
     enum:
       - COMMANDECHO
@@ -41,6 +44,7 @@ types:
       PathEvent: PathEvent
       QueryEvent: QueryEvent
       MultiEvent: MultiEvent
+      BodyEvent: BodyEvent
   # Request Structure
   RequestInfo:
     properties:

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -9,6 +9,50 @@ import (
 	time "time"
 )
 
+type BodyXmlRpcFunctionAuthConfig struct {
+	Targets []string `json:"targets,omitempty" url:"targets,omitempty"`
+	Timeout int      `json:"timeout" url:"timeout"`
+	Retries int      `json:"retries" url:"retries"`
+	Sleep   int      `json:"sleep" url:"sleep"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (b *BodyXmlRpcFunctionAuthConfig) GetExtraProperties() map[string]interface{} {
+	return b.extraProperties
+}
+
+func (b *BodyXmlRpcFunctionAuthConfig) UnmarshalJSON(data []byte) error {
+	type unmarshaler BodyXmlRpcFunctionAuthConfig
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*b = BodyXmlRpcFunctionAuthConfig(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *b)
+	if err != nil {
+		return err
+	}
+	b.extraProperties = extraProperties
+
+	b._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (b *BodyXmlRpcFunctionAuthConfig) String() string {
+	if len(b._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(b._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(b); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", b)
+}
+
 type HeaderBufferOverflowConfig struct {
 	Targets  []string `json:"targets,omitempty" url:"targets,omitempty"`
 	BodySize int      `json:"bodySize" url:"bodySize"`
@@ -870,12 +914,32 @@ func (t *TargetInfo) String() string {
 	return fmt.Sprintf("%#v", t)
 }
 
+type BodyEvent string
+
+const (
+	BodyEventXmlrpcfunctionauth BodyEvent = "XMLRPCFUNCTIONAUTH"
+)
+
+func NewBodyEventFromString(s string) (BodyEvent, error) {
+	switch s {
+	case "XMLRPCFUNCTIONAUTH":
+		return BodyEventXmlrpcfunctionauth, nil
+	}
+	var t BodyEvent
+	return "", fmt.Errorf("%s is not a valid %T", s, t)
+}
+
+func (b BodyEvent) Ptr() *BodyEvent {
+	return &b
+}
+
 type EventType struct {
 	Type        string
 	HeaderEvent HeaderEvent
 	PathEvent   PathEvent
 	QueryEvent  QueryEvent
 	MultiEvent  MultiEvent
+	BodyEvent   BodyEvent
 }
 
 func NewEventTypeFromHeaderEvent(value HeaderEvent) *EventType {
@@ -892,6 +956,10 @@ func NewEventTypeFromQueryEvent(value QueryEvent) *EventType {
 
 func NewEventTypeFromMultiEvent(value MultiEvent) *EventType {
 	return &EventType{Type: "MultiEvent", MultiEvent: value}
+}
+
+func NewEventTypeFromBodyEvent(value BodyEvent) *EventType {
+	return &EventType{Type: "BodyEvent", BodyEvent: value}
 }
 
 func (e *EventType) UnmarshalJSON(data []byte) error {
@@ -938,6 +1006,14 @@ func (e *EventType) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		e.MultiEvent = valueUnmarshaler.MultiEvent
+	case "BodyEvent":
+		var valueUnmarshaler struct {
+			BodyEvent BodyEvent `json:"value"`
+		}
+		if err := json.Unmarshal(data, &valueUnmarshaler); err != nil {
+			return err
+		}
+		e.BodyEvent = valueUnmarshaler.BodyEvent
 	}
 	return nil
 }
@@ -982,6 +1058,15 @@ func (e EventType) MarshalJSON() ([]byte, error) {
 			MultiEvent: e.MultiEvent,
 		}
 		return json.Marshal(marshaler)
+	case "BodyEvent":
+		var marshaler = struct {
+			Type      string    `json:"type"`
+			BodyEvent BodyEvent `json:"value"`
+		}{
+			Type:      "BodyEvent",
+			BodyEvent: e.BodyEvent,
+		}
+		return json.Marshal(marshaler)
 	}
 }
 
@@ -990,6 +1075,7 @@ type EventTypeVisitor interface {
 	VisitPathEvent(PathEvent) error
 	VisitQueryEvent(QueryEvent) error
 	VisitMultiEvent(MultiEvent) error
+	VisitBodyEvent(BodyEvent) error
 }
 
 func (e *EventType) Accept(visitor EventTypeVisitor) error {
@@ -1004,6 +1090,8 @@ func (e *EventType) Accept(visitor EventTypeVisitor) error {
 		return visitor.VisitQueryEvent(e.QueryEvent)
 	case "MultiEvent":
 		return visitor.VisitMultiEvent(e.MultiEvent)
+	case "BodyEvent":
+		return visitor.VisitBodyEvent(e.BodyEvent)
 	}
 }
 

--- a/internal/wordpress/body/xmlrpc/functionauth.go
+++ b/internal/wordpress/body/xmlrpc/functionauth.go
@@ -1,0 +1,154 @@
+package body
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	"github.com/Method-Security/methodwebtest/utils"
+)
+
+var xmlrpcPath = "/xmlrpc.php"
+
+func PerformBodyXMLRPCFunctionAuthInjection(ctx context.Context, config *methodwebtest.BodyXmlRpcFunctionAuthConfig) methodwebtest.Report {
+	report := methodwebtest.Report{}
+	var allErrors []string
+
+	var targets []*methodwebtest.TargetInfo
+	for _, target := range config.Targets {
+		targetInfo := methodwebtest.TargetInfo{Target: target, StartTimestamp: time.Now()}
+
+		// Split target
+		baseURL, parsedPath, err := utils.SplitTarget(target)
+		if err != nil {
+			allErrors = append(allErrors, err.Error())
+			continue
+		}
+		xmlrpcPathParsedPath := parsedPath + xmlrpcPath
+
+		// Base request -  Gather xmlrpc functions
+		startTime := time.Now()
+		grabXMLRPCFunctionsRequest := utils.PerformRequestScan(
+			baseURL,
+			xmlrpcPathParsedPath,
+			methodwebtest.HttpMethodPost,
+			methodwebtest.RequestParams{BodyParams: "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.listMethods</methodName></methodCall>"},
+			[]*methodwebtest.EventType{},
+			config.Timeout, true)
+		endTime := time.Now()
+
+		// Marshal base attempt
+		baselineAttempt := methodwebtest.AttemptInfo{
+			Request:      &grabXMLRPCFunctionsRequest,
+			TimeSent:     startTime,
+			TimeReceived: &endTime,
+		}
+		if !detectSuccessfulXmlrpcGrab(grabXMLRPCFunctionsRequest) {
+			targetInfo.RequestCount = 0
+			targetInfo.BaselineAttempt = &baselineAttempt
+			targetInfo.EndTimestamp = time.Now()
+			targets = append(targets, &targetInfo)
+			allErrors = append(allErrors, "Failed to grab xmlrpc functions")
+			continue
+		}
+
+		passedXMLRPCFunctions := parseXMLRPCFunctions(grabXMLRPCFunctionsRequest.ResponseBody)
+
+		attempts := []*methodwebtest.AttemptInfo{}
+		for _, function := range passedXMLRPCFunctions {
+			attempt := methodwebtest.AttemptInfo{}
+
+			// Generate xmlrpc payload
+			bodyParams := generateFunctionAuthBodyInjectionParam(function)
+
+			// Send request
+			startTime := time.Now()
+			request := utils.PerformRequestScan(
+				baseURL,
+				xmlrpcPathParsedPath,
+				methodwebtest.HttpMethodPost,
+				methodwebtest.RequestParams{BodyParams: bodyParams},
+				[]*methodwebtest.EventType{methodwebtest.NewEventTypeFromBodyEvent(methodwebtest.BodyEventXmlrpcfunctionauth)},
+				config.Timeout, true)
+			endTime := time.Now()
+
+			// Marshal attempt info
+			attempt.Finding = detectSuccessfulFunctionAuth(&request)
+			attempt.TimeSent = startTime
+			attempt.TimeReceived = &endTime
+			attempt.Request = &request
+			attempts = append(attempts, &attempt)
+		}
+
+		// Marshal target info
+		targetInfo.RequestCount = len(passedXMLRPCFunctions)
+		targetInfo.BaselineAttempt = &baselineAttempt
+		targetInfo.Attempts = attempts
+		targetInfo.EndTimestamp = time.Now()
+		targets = append(targets, &targetInfo)
+	}
+	report.Targets = targets
+	report.Errors = allErrors
+	return report
+}
+
+func detectSuccessfulXmlrpcGrab(requestInfo methodwebtest.RequestInfo) bool {
+	// Check if the response contains a valid XML-RPC response
+	if requestInfo.ResponseBody == nil {
+		return false
+	}
+	body := *requestInfo.ResponseBody
+	return strings.Contains(body, "<methodResponse>") && strings.Contains(body, "<params>")
+}
+
+func parseXMLRPCFunctions(responseBody *string) []string {
+	if responseBody == nil {
+		return []string{}
+	}
+
+	// Extract function names from XML response
+	var functions []string
+	re := regexp.MustCompile(`<value><string>([^<]+)</string></value>`)
+	matches := re.FindAllStringSubmatch(*responseBody, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			functions = append(functions, match[1])
+		}
+	}
+
+	return functions
+}
+
+func generateFunctionAuthBodyInjectionParam(function string) string {
+	// Generate an unauthenticated XML-RPC request for the function
+	payload := fmt.Sprintf(`<?xml version="1.0"?>
+		<methodCall>
+			<methodName>%s</methodName>
+			<params>
+			</params>
+		</methodCall>`, function)
+
+	return payload
+}
+
+func detectSuccessfulFunctionAuth(requestInfo *methodwebtest.RequestInfo) *bool {
+	success := false
+	if requestInfo == nil || requestInfo.ResponseBody == nil {
+		return &success
+	}
+
+	if requestInfo.StatusCode == nil || *requestInfo.StatusCode != 200 {
+		return &success
+	}
+
+	body := *requestInfo.ResponseBody
+	success = strings.Contains(body, "<param>") &&
+		!strings.Contains(body, "Invalid method parameters") &&
+		!strings.Contains(body, "<fault>") &&
+		!strings.Contains(body, "<name>faultCode</name>")
+	return &success
+}


### PR DESCRIPTION
## Goal

- Detect whether the xmlrpc.php file is publicly accessible.
- If exposed, enumerate all available XML-RPC functions.
- Analyze the returned functions to determine if authentication is required.

## Why

- XML-RPC can introduce security risks, including brute force attacks, DDoS amplification, and unauthenticated function execution.
- Identifying exposed XML-RPC endpoints helps assess potential vulnerabilities and strengthen security controls.


## Note 1

This is why matches is a List of Lists/ hardcoded to [1]

```
matches = [
  ["<value><string>system.listMethods</string></value>", "system.listMethods"],
  ["<value><string>metaWeblog.newPost</string></value>", "metaWeblog.newPost"],
  ["<value><string>blogger.deletePost</string></value>", "blogger.deletePost"]
]
```

## Note 2

This one might be hard to parse from the code. let me know if you want a command to run it
