### PR TITLE
Apache Options Bleed Tool

### DIFF
--- a/cmd/apache.go
+++ b/cmd/apache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	header "github.com/Method-Security/methodwebtest/internal/apache/header"
 	path "github.com/Method-Security/methodwebtest/internal/apache/path"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,61 @@ func (a *MethodWebTest) InitApacheCommand() {
 	apacheCmd.PersistentFlags().Int("timeout", 30, "Timeout per request (seconds)")
 	apacheCmd.PersistentFlags().Int("sleep", 0, "Sleep time between requests (seconds)")
 	apacheCmd.PersistentFlags().Int("retries", 0, "Number of attempts per credential pair")
+
+	headerCmd := &cobra.Command{
+		Use:   "header",
+		Short: "Perform header injection tests against a target",
+		Long:  `Perform header injection tests against a target`,
+	}
+
+	optionsBleedCmd := &cobra.Command{
+		Use:   "optionsbleed",
+		Short: "Perform options bleed tests against a target",
+		Long:  `Perform options bleed tests against a target`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Target flags
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(targets) == 0 {
+				a.OutputSignal.AddError(errors.New("no targets provided"))
+				return
+			}
+
+			// Configuration flags
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			retries, err := cmd.Flags().GetInt("retries")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Load configuration
+			config := LoadHeaderOptionsBleedConfig(targets, timeout, sleep, retries)
+
+			// Generate report
+			report := header.PerformApacheHeaderOptionsBleedInjection(cmd.Context(), config)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	headerCmd.AddCommand(optionsBleedCmd)
 
 	// pathCmd holds the subcommands for path injection tests
 	pathCmd := &cobra.Command{
@@ -151,9 +207,25 @@ func (a *MethodWebTest) InitApacheCommand() {
 
 	pathCmd.AddCommand(traversalCmd)
 
+	apacheCmd.AddCommand(headerCmd)
 	apacheCmd.AddCommand(pathCmd)
 
 	a.RootCmd.AddCommand(apacheCmd)
+}
+
+func LoadHeaderOptionsBleedConfig(targets []string, timeout int, sleep int, retries int) *methodwebtest.HeaderOptionsBleedConfig {
+	config := &methodwebtest.HeaderOptionsBleedConfig{
+		Targets: targets,
+		Timeout: timeout,
+		Sleep:   sleep,
+		Retries: retries,
+	}
+
+	if config.Timeout < 1 {
+		config.Timeout = 0
+	}
+
+	return config
 }
 
 func LoadPathModFileConfig(targets []string, timeout int, sleep int, retries int) *methodwebtest.PathModFileConfig {

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -31,6 +31,12 @@ types:
       timeout: integer
       retries: integer
       sleep: integer
+  HeaderOptionsBleedConfig:
+    properties:
+      targets: list<string>
+      timeout: integer
+      retries: integer
+      sleep: integer
   # Path Configs
   PathCrlfConfig:
     properties:

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -20,6 +20,7 @@ types:
       - SENSITIVEEXPOSED
       - SERVEROVERLOAD
       - USERAGENT
+      - OPTIONSBLEED
   PathEvent:
     enum:
       - TRAVERSAL

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -143,6 +143,50 @@ func (h *HeaderMisconfigurationConfig) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+type HeaderOptionsBleedConfig struct {
+	Targets []string `json:"targets,omitempty" url:"targets,omitempty"`
+	Timeout int      `json:"timeout" url:"timeout"`
+	Retries int      `json:"retries" url:"retries"`
+	Sleep   int      `json:"sleep" url:"sleep"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderOptionsBleedConfig) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderOptionsBleedConfig) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderOptionsBleedConfig
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderOptionsBleedConfig(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderOptionsBleedConfig) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
 type HeaderServerOverloadConfig struct {
 	Targets     []string `json:"targets,omitempty" url:"targets,omitempty"`
 	HeaderNames []string `json:"headerNames,omitempty" url:"headerNames,omitempty"`
@@ -1104,6 +1148,7 @@ const (
 	HeaderEventSensitiveexposed HeaderEvent = "SENSITIVEEXPOSED"
 	HeaderEventServeroverload   HeaderEvent = "SERVEROVERLOAD"
 	HeaderEventUseragent        HeaderEvent = "USERAGENT"
+	HeaderEventOptionsbleed     HeaderEvent = "OPTIONSBLEED"
 )
 
 func NewHeaderEventFromString(s string) (HeaderEvent, error) {
@@ -1120,6 +1165,8 @@ func NewHeaderEventFromString(s string) (HeaderEvent, error) {
 		return HeaderEventServeroverload, nil
 	case "USERAGENT":
 		return HeaderEventUseragent, nil
+	case "OPTIONSBLEED":
+		return HeaderEventOptionsbleed, nil
 	}
 	var t HeaderEvent
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/internal/apache/header/optionsbleed.go
+++ b/internal/apache/header/optionsbleed.go
@@ -1,0 +1,65 @@
+package header
+
+import (
+	"context"
+	"strings"
+
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	utils "github.com/Method-Security/methodwebtest/utils/engines"
+)
+
+func PerformApacheHeaderOptionsBleedInjection(ctx context.Context, config *methodwebtest.HeaderOptionsBleedConfig) *methodwebtest.Report {
+	injectionConfig := methodwebtest.InjectionEngineConfig{
+		Targets:           config.Targets,
+		Method:            methodwebtest.HttpMethodOptions,
+		Paths:             []string{""},
+		InjectedPayloads:  []map[string]string{{"Access-Control-Request-Method": "GET"}},
+		InjectionLocation: methodwebtest.InjectionLocationHeader,
+		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventOptionsbleed),
+		Timeout:           config.Timeout,
+		Retries:           config.Retries,
+		Sleep:             config.Sleep,
+	}
+
+	report := utils.RunMultiInjectionsEngine(ctx, &injectionConfig)
+	detectOptionsBleed(report)
+	report.Config = methodwebtest.NewEngineConfigFromInjectionEngineConfig(&injectionConfig)
+	return report
+}
+
+func detectOptionsBleed(report *methodwebtest.Report) {
+	corruptedIndicators := []string{
+		"@@@@", "???", "\x00", "\xff", "�",
+	}
+	for _, target := range report.Targets {
+		if target.Attempts == nil {
+			continue
+		}
+		for _, attempt := range target.Attempts {
+			finding := false
+			allowHeader := ""
+			exists := false
+			// Normalize headers to check case-insensitively
+			for headerKey, headerValue := range attempt.Request.ResponseHeaders {
+				if strings.ToLower(headerKey) == "allow" {
+					allowHeader = headerValue
+					exists = true
+					break
+				}
+			}
+			// If "Allow" header is missing, it's suspicious
+			if !exists {
+				finding = true
+			} else {
+				// Look for corrupted indicators
+				for _, indicator := range corruptedIndicators {
+					if strings.Contains(allowHeader, indicator) {
+						finding = true
+						break
+					}
+				}
+			}
+			attempt.Finding = &finding
+		}
+	}
+}


### PR DESCRIPTION
## Update

- Added a tool to test for OptionsBleed (CVE-2017-9798) in Apache by sending malformed OPTIONS requests.

## CVE Details

- CVE-2017-9798: Apache may leak memory in the Allow header, potentially exposing sensitive data.

## Impact

- Attackers can retrieve fragments of server memory, which may contain credentials, configuration details, or other sensitive information.