### PR TITLE
Apache Lua Buffer Overflow Tool

### DIFF
--- a/cmd/apache.go
+++ b/cmd/apache.go
@@ -77,6 +77,64 @@ func (a *MethodWebTest) InitApacheCommand() {
 
 	headerCmd.AddCommand(optionsBleedCmd)
 
+	luaBufferOverflowCmd := &cobra.Command{
+		Use:   "luabufferoverflow",
+		Short: "Perform lua buffer overflow tests against a target",
+		Long:  `Perform lua buffer overflow tests against a target`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Target flags
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(targets) == 0 {
+				a.OutputSignal.AddError(errors.New("no targets provided"))
+				return
+			}
+
+			// Configuration flags
+			misconfiguredHeaderSize, err := cmd.Flags().GetInt("misconfiguredheadersize")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			retries, err := cmd.Flags().GetInt("retries")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Load configuration
+			config := LoadHeaderLuaBufferOverflowConfig(targets, timeout, sleep, retries, misconfiguredHeaderSize)
+
+			// Generate report
+			report := header.PerformApacheHeaderLuaBufferOverflowInjection(cmd.Context(), config)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	luaBufferOverflowCmd.Flags().Int("misconfiguredheadersize", 1000000, "Misconfigured header size to use for lua buffer overflow")
+
+	_ = luaBufferOverflowCmd.MarkFlagRequired("misconfiguredheadersize")
+
+	headerCmd.AddCommand(luaBufferOverflowCmd)
+
 	// pathCmd holds the subcommands for path injection tests
 	pathCmd := &cobra.Command{
 		Use:   "path",
@@ -228,6 +286,21 @@ func LoadHeaderOptionsBleedConfig(targets []string, timeout int, sleep int, retr
 	return config
 }
 
+func LoadHeaderLuaBufferOverflowConfig(targets []string, timeout int, sleep int, retries int, misconfiguredHeaderSize int) *methodwebtest.HeaderLuaBufferOverflowConfig {
+	config := &methodwebtest.HeaderLuaBufferOverflowConfig{
+		Targets:                 targets,
+		MisconfiguredHeaderSize: misconfiguredHeaderSize,
+		Timeout:                 timeout,
+		Sleep:                   sleep,
+		Retries:                 retries,
+	}
+
+	if config.Timeout < 1 {
+		config.Timeout = 0
+	}
+
+	return config
+}
 func LoadPathModFileConfig(targets []string, timeout int, sleep int, retries int) *methodwebtest.PathModFileConfig {
 	config := &methodwebtest.PathModFileConfig{
 		Targets: targets,

--- a/cmd/apache.go
+++ b/cmd/apache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	header "github.com/Method-Security/methodwebtest/internal/apache/header"
 	path "github.com/Method-Security/methodwebtest/internal/apache/path"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,61 @@ func (a *MethodWebTest) InitApacheCommand() {
 	apacheCmd.PersistentFlags().Int("timeout", 30, "Timeout per request (seconds)")
 	apacheCmd.PersistentFlags().Int("sleep", 0, "Sleep time between requests (seconds)")
 	apacheCmd.PersistentFlags().Int("retries", 0, "Number of attempts per credential pair")
+
+	headerCmd := &cobra.Command{
+		Use:   "header",
+		Short: "Perform header injection tests against a target",
+		Long:  `Perform header injection tests against a target`,
+	}
+
+	optionsBleedCmd := &cobra.Command{
+		Use:   "optionsbleed",
+		Short: "Perform options bleed tests against a target",
+		Long:  `Perform options bleed tests against a target`,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer a.OutputSignal.PanicHandler(cmd.Context())
+
+			// Target flags
+			targets, err := cmd.Flags().GetStringSlice("targets")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(targets) == 0 {
+				a.OutputSignal.AddError(errors.New("no targets provided"))
+				return
+			}
+
+			// Configuration flags
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			sleep, err := cmd.Flags().GetInt("sleep")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			retries, err := cmd.Flags().GetInt("retries")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Load configuration
+			config := LoadHeaderOptionsBleedConfig(targets, timeout, sleep, retries)
+
+			// Generate report
+			report := header.PerformApacheHeaderOptionsBleedInjection(cmd.Context(), config)
+			if len(report.Errors) > 0 {
+				a.OutputSignal.Status = 1
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	headerCmd.AddCommand(optionsBleedCmd)
 
 	// pathCmd holds the subcommands for path injection tests
 	pathCmd := &cobra.Command{
@@ -151,9 +207,25 @@ func (a *MethodWebTest) InitApacheCommand() {
 
 	pathCmd.AddCommand(traversalCmd)
 
+	apacheCmd.AddCommand(headerCmd)
 	apacheCmd.AddCommand(pathCmd)
 
 	a.RootCmd.AddCommand(apacheCmd)
+}
+
+func LoadHeaderOptionsBleedConfig(targets []string, timeout int, sleep int, retries int) *methodwebtest.HeaderOptionsBleedConfig {
+	config := &methodwebtest.HeaderOptionsBleedConfig{
+		Targets: targets,
+		Timeout: timeout,
+		Sleep:   sleep,
+		Retries: retries,
+	}
+
+	if config.Timeout < 1 {
+		config.Timeout = 0
+	}
+
+	return config
 }
 
 func LoadPathModFileConfig(targets []string, timeout int, sleep int, retries int) *methodwebtest.PathModFileConfig {

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -37,6 +37,13 @@ types:
       timeout: integer
       retries: integer
       sleep: integer
+  HeaderLuaBufferOverflowConfig:
+    properties:
+      targets: list<string>
+      misconfiguredHeaderSize: integer
+      timeout: integer
+      retries: integer
+      sleep: integer
   # Path Configs
   PathCrlfConfig:
     properties:

--- a/fern/definition/configs.yml
+++ b/fern/definition/configs.yml
@@ -31,6 +31,12 @@ types:
       timeout: integer
       retries: integer
       sleep: integer
+  HeaderOptionsBleedConfig:
+    properties:
+      targets: list<string>
+      timeout: integer
+      retries: integer
+      sleep: integer
   # Path Configs
   PathCrlfConfig:
     properties:

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -20,6 +20,7 @@ types:
       - SENSITIVEEXPOSED
       - SERVEROVERLOAD
       - USERAGENT
+      - OPTIONSBLEED
   PathEvent:
     enum:
       - TRAVERSAL

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -21,6 +21,7 @@ types:
       - SERVEROVERLOAD
       - USERAGENT
       - OPTIONSBLEED
+      - LUABUFFEROVERFLOW
   PathEvent:
     enum:
       - TRAVERSAL

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -143,6 +143,50 @@ func (h *HeaderMisconfigurationConfig) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+type HeaderOptionsBleedConfig struct {
+	Targets []string `json:"targets,omitempty" url:"targets,omitempty"`
+	Timeout int      `json:"timeout" url:"timeout"`
+	Retries int      `json:"retries" url:"retries"`
+	Sleep   int      `json:"sleep" url:"sleep"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderOptionsBleedConfig) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderOptionsBleedConfig) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderOptionsBleedConfig
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderOptionsBleedConfig(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderOptionsBleedConfig) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
 type HeaderServerOverloadConfig struct {
 	Targets     []string `json:"targets,omitempty" url:"targets,omitempty"`
 	HeaderNames []string `json:"headerNames,omitempty" url:"headerNames,omitempty"`
@@ -1104,6 +1148,7 @@ const (
 	HeaderEventSensitiveexposed HeaderEvent = "SENSITIVEEXPOSED"
 	HeaderEventServeroverload   HeaderEvent = "SERVEROVERLOAD"
 	HeaderEventUseragent        HeaderEvent = "USERAGENT"
+	HeaderEventOptionsbleed     HeaderEvent = "OPTIONSBLEED"
 )
 
 func NewHeaderEventFromString(s string) (HeaderEvent, error) {
@@ -1120,6 +1165,8 @@ func NewHeaderEventFromString(s string) (HeaderEvent, error) {
 		return HeaderEventServeroverload, nil
 	case "USERAGENT":
 		return HeaderEventUseragent, nil
+	case "OPTIONSBLEED":
+		return HeaderEventOptionsbleed, nil
 	}
 	var t HeaderEvent
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -98,6 +98,51 @@ func (h *HeaderBufferOverflowConfig) String() string {
 	return fmt.Sprintf("%#v", h)
 }
 
+type HeaderLuaBufferOverflowConfig struct {
+	Targets                 []string `json:"targets,omitempty" url:"targets,omitempty"`
+	MisconfiguredHeaderSize int      `json:"misconfiguredHeaderSize" url:"misconfiguredHeaderSize"`
+	Timeout                 int      `json:"timeout" url:"timeout"`
+	Retries                 int      `json:"retries" url:"retries"`
+	Sleep                   int      `json:"sleep" url:"sleep"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (h *HeaderLuaBufferOverflowConfig) GetExtraProperties() map[string]interface{} {
+	return h.extraProperties
+}
+
+func (h *HeaderLuaBufferOverflowConfig) UnmarshalJSON(data []byte) error {
+	type unmarshaler HeaderLuaBufferOverflowConfig
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*h = HeaderLuaBufferOverflowConfig(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *h)
+	if err != nil {
+		return err
+	}
+	h.extraProperties = extraProperties
+
+	h._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (h *HeaderLuaBufferOverflowConfig) String() string {
+	if len(h._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(h._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(h); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", h)
+}
+
 type HeaderMisconfigurationConfig struct {
 	Targets     []string    `json:"targets,omitempty" url:"targets,omitempty"`
 	HeaderEvent HeaderEvent `json:"headerEvent" url:"headerEvent"`
@@ -1142,13 +1187,14 @@ func (e *EventType) Accept(visitor EventTypeVisitor) error {
 type HeaderEvent string
 
 const (
-	HeaderEventCors             HeaderEvent = "CORS"
-	HeaderEventEscape           HeaderEvent = "ESCAPE"
-	HeaderEventHttp             HeaderEvent = "HTTP"
-	HeaderEventSensitiveexposed HeaderEvent = "SENSITIVEEXPOSED"
-	HeaderEventServeroverload   HeaderEvent = "SERVEROVERLOAD"
-	HeaderEventUseragent        HeaderEvent = "USERAGENT"
-	HeaderEventOptionsbleed     HeaderEvent = "OPTIONSBLEED"
+	HeaderEventCors              HeaderEvent = "CORS"
+	HeaderEventEscape            HeaderEvent = "ESCAPE"
+	HeaderEventHttp              HeaderEvent = "HTTP"
+	HeaderEventSensitiveexposed  HeaderEvent = "SENSITIVEEXPOSED"
+	HeaderEventServeroverload    HeaderEvent = "SERVEROVERLOAD"
+	HeaderEventUseragent         HeaderEvent = "USERAGENT"
+	HeaderEventOptionsbleed      HeaderEvent = "OPTIONSBLEED"
+	HeaderEventLuabufferoverflow HeaderEvent = "LUABUFFEROVERFLOW"
 )
 
 func NewHeaderEventFromString(s string) (HeaderEvent, error) {
@@ -1167,6 +1213,8 @@ func NewHeaderEventFromString(s string) (HeaderEvent, error) {
 		return HeaderEventUseragent, nil
 	case "OPTIONSBLEED":
 		return HeaderEventOptionsbleed, nil
+	case "LUABUFFEROVERFLOW":
+		return HeaderEventLuabufferoverflow, nil
 	}
 	var t HeaderEvent
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/internal/apache/header/luabufferoverflow.go
+++ b/internal/apache/header/luabufferoverflow.go
@@ -1,0 +1,122 @@
+package header
+
+import (
+	"context"
+	"strings"
+
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	utils "github.com/Method-Security/methodwebtest/utils/engines"
+)
+
+var luaPaths = []string{
+	// lua handler paths
+	"/lua-handler",
+
+	// Common Lua script endpoints
+	"/lua",
+	"/lua/index.lua",
+	"/scripts/lua",
+	"/cgi-bin/lua",
+	"/handlers/lua",
+	"/modules/lua",
+
+	// API endpoints often implemented in Lua
+	"/api/upload",
+	"/api/v1/proxy",
+	"/api/v1/gateway",
+	"/api/gateway",
+	"/api/transform",
+	"/api/lua/execute",
+	"/api/v1/lua-handler",
+	"/api/v1/process-data",
+	"/api/parse-body",
+	"/lua-api",
+
+	// Control panel/admin interfaces
+	"/admin/scripts",
+	"/admin/lua",
+	"/dashboard/lua",
+	"/control/execute",
+	"/manager/lua-config",
+
+	// Common extensions
+	"/handler.lua",
+	"/script.lua",
+	"/execute.lua",
+	"/process.lp",
+	"/index.luac",
+}
+
+func PerformApacheHeaderLuaBufferOverflowInjection(ctx context.Context, config *methodwebtest.HeaderLuaBufferOverflowConfig) *methodwebtest.Report {
+	injectionConfig := methodwebtest.InjectionEngineConfig{
+		Targets:           config.Targets,
+		Method:            methodwebtest.HttpMethodGet,
+		Paths:             luaPaths,
+		BaselinePayload:   map[string]string{},
+		InjectedPayloads:  generatePayloads(config.MisconfiguredHeaderSize),
+		InjectionLocation: methodwebtest.InjectionLocationHeader,
+		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventLuabufferoverflow),
+		Timeout:           config.Timeout,
+		Retries:           config.Retries,
+		Sleep:             config.Sleep,
+	}
+
+	report := utils.RunMultiInjectionsEngine(ctx, &injectionConfig)
+	detectLuaBufferOverflow(report)
+	report.Config = methodwebtest.NewEngineConfigFromInjectionEngineConfig(&injectionConfig)
+	return report
+}
+
+// generatePayloads generates payloads for the lua buffer overflow test
+func generatePayloads(misconfiguredHeaderSize int) []map[string]string {
+	return []map[string]string{
+		{"User-Agent": strings.Repeat("A", misconfiguredHeaderSize)},
+		{"User-Agent": strings.Repeat("A", misconfiguredHeaderSize/2) + "\x00\x41\x42\x00" + strings.Repeat("B", misconfiguredHeaderSize/2)},
+	}
+}
+
+// detectLuaBufferOverflow scans the report for Lua buffer overflow errors, case-insensitively.
+func detectLuaBufferOverflow(report *methodwebtest.Report) {
+	// Indicators of Lua buffer overflow issues (case-insensitive)
+	luaOverflowIndicators := []string{
+		"attempt to index a nil value", // Common Lua runtime error
+		"bad argument",                 // Argument parsing failure
+		"invalid memory access",        // Possible memory corruption
+		"stack overflow",               // Lua stack overflow error
+		"panic",                        // Lua panic state
+		"segmentation fault",           // Apache crash due to Lua bug
+		"core dumped",                  // Fatal error causing Apache to dump core
+	}
+
+	for _, target := range report.Targets {
+		if target.Attempts == nil || target.BaselineAttempt == nil {
+			continue
+		}
+
+		// Skip targets that don't have a baseline attempt or have a baseline attempt with a not 200 status code
+		if target.BaselineAttempt.Request == nil || target.BaselineAttempt.Request.StatusCode == nil || *target.BaselineAttempt.Request.StatusCode != 200 {
+			continue
+		}
+
+		for _, attempt := range target.Attempts {
+			finding := false
+			// Check response body for Lua-specific errors (case-insensitive)
+			if attempt.Request != nil && attempt.Request.ResponseBody != nil {
+				// Baseline attempt is 200, but the attempt is 500 or higher suggests a buffer overflow
+				if attempt.Request.StatusCode == nil || *attempt.Request.StatusCode >= 500 {
+					finding = true
+				}
+				if !finding {
+					lowerResponseBody := strings.ToLower(*attempt.Request.ResponseBody) // Convert response body to lowercase
+					for _, indicator := range luaOverflowIndicators {
+						if strings.Contains(lowerResponseBody, strings.ToLower(indicator)) {
+							finding = true
+							break
+						}
+					}
+				}
+			}
+			attempt.Finding = &finding
+		}
+	}
+}

--- a/internal/apache/header/optionsbleed.go
+++ b/internal/apache/header/optionsbleed.go
@@ -1,0 +1,65 @@
+package header
+
+import (
+	"context"
+	"strings"
+
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	utils "github.com/Method-Security/methodwebtest/utils/engines"
+)
+
+func PerformApacheHeaderOptionsBleedInjection(ctx context.Context, config *methodwebtest.HeaderOptionsBleedConfig) *methodwebtest.Report {
+	injectionConfig := methodwebtest.InjectionEngineConfig{
+		Targets:           config.Targets,
+		Method:            methodwebtest.HttpMethodOptions,
+		Paths:             []string{""},
+		InjectedPayloads:  []map[string]string{{"Access-Control-Request-Method": "GET"}},
+		InjectionLocation: methodwebtest.InjectionLocationHeader,
+		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventOptionsbleed),
+		Timeout:           config.Timeout,
+		Retries:           config.Retries,
+		Sleep:             config.Sleep,
+	}
+
+	report := utils.RunMultiInjectionsEngine(ctx, &injectionConfig)
+	detectOptionsBleed(report)
+	report.Config = methodwebtest.NewEngineConfigFromInjectionEngineConfig(&injectionConfig)
+	return report
+}
+
+func detectOptionsBleed(report *methodwebtest.Report) {
+	corruptedIndicators := []string{
+		"@@@@", "???", "\x00", "\xff", "�",
+	}
+	for _, target := range report.Targets {
+		if target.Attempts == nil {
+			continue
+		}
+		for _, attempt := range target.Attempts {
+			finding := false
+			allowHeader := ""
+			exists := false
+			// Normalize headers to check case-insensitively
+			for headerKey, headerValue := range attempt.Request.ResponseHeaders {
+				if strings.ToLower(headerKey) == "allow" {
+					allowHeader = headerValue
+					exists = true
+					break
+				}
+			}
+			// If "Allow" header is missing, it's suspicious
+			if !exists {
+				finding = true
+			} else {
+				// Look for corrupted indicators
+				for _, indicator := range corruptedIndicators {
+					if strings.Contains(allowHeader, indicator) {
+						finding = true
+						break
+					}
+				}
+			}
+			attempt.Finding = &finding
+		}
+	}
+}


### PR DESCRIPTION
## Update

Added a tool to test for Lua buffer overflow vulnerabilities in Apache's mod_lua by sending malformed requests.

## CVE Details

CVE-2021-44790: A buffer overflow vulnerability exists in the mod_lua module of Apache HTTP Server versions 2.4.51 and earlier. This flaw occurs when the r:parsebody() function in Lua scripts processes a maliciously crafted request body, potentially leading to memory corruption or execution errors. ​


## Impact

Attackers can trigger segmentation faults, stack overflows, or core dumps, which may expose sensitive server information or cause denial-of-service (DoS) conditions.