### PR TITLE
MethodWebtest: Folllow Redirect Update

### DIFF
--- a/fern/definition/report.yml
+++ b/fern/definition/report.yml
@@ -12,6 +12,7 @@ types:
       injectedPayloads: list<map<string, string>>
       injectionLocation: configs.InjectionLocation
       eventType: request.EventType
+      followRedirects: boolean
       timeout: integer
       retries: integer
       sleep: integer
@@ -21,6 +22,7 @@ types:
       method: request.HttpMethod
       payloads: list<list<map<string, string>>>
       eventType: request.EventType
+      followRedirects: boolean
       timeout: integer
       retries: integer
       sleep: integer

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -699,13 +699,14 @@ func (e *EngineConfig) Accept(visitor EngineConfigVisitor) error {
 }
 
 type HeaderMisconfigurationEngineConfig struct {
-	Targets   []string              `json:"targets,omitempty" url:"targets,omitempty"`
-	Method    HttpMethod            `json:"method" url:"method"`
-	Payloads  [][]map[string]string `json:"payloads,omitempty" url:"payloads,omitempty"`
-	EventType *EventType            `json:"eventType,omitempty" url:"eventType,omitempty"`
-	Timeout   int                   `json:"timeout" url:"timeout"`
-	Retries   int                   `json:"retries" url:"retries"`
-	Sleep     int                   `json:"sleep" url:"sleep"`
+	Targets         []string              `json:"targets,omitempty" url:"targets,omitempty"`
+	Method          HttpMethod            `json:"method" url:"method"`
+	Payloads        [][]map[string]string `json:"payloads,omitempty" url:"payloads,omitempty"`
+	EventType       *EventType            `json:"eventType,omitempty" url:"eventType,omitempty"`
+	FollowRedirects bool                  `json:"followRedirects" url:"followRedirects"`
+	Timeout         int                   `json:"timeout" url:"timeout"`
+	Retries         int                   `json:"retries" url:"retries"`
+	Sleep           int                   `json:"sleep" url:"sleep"`
 
 	extraProperties map[string]interface{}
 	_rawJSON        json.RawMessage
@@ -753,6 +754,7 @@ type InjectionEngineConfig struct {
 	InjectedPayloads  []map[string]string `json:"injectedPayloads,omitempty" url:"injectedPayloads,omitempty"`
 	InjectionLocation InjectionLocation   `json:"injectionLocation" url:"injectionLocation"`
 	EventType         *EventType          `json:"eventType,omitempty" url:"eventType,omitempty"`
+	FollowRedirects   bool                `json:"followRedirects" url:"followRedirects"`
 	Timeout           int                 `json:"timeout" url:"timeout"`
 	Retries           int                 `json:"retries" url:"retries"`
 	Sleep             int                 `json:"sleep" url:"sleep"`

--- a/internal/apache/header/optionsbleed.go
+++ b/internal/apache/header/optionsbleed.go
@@ -16,6 +16,7 @@ func PerformApacheHeaderOptionsBleedInjection(ctx context.Context, config *metho
 		InjectedPayloads:  []map[string]string{{"Access-Control-Request-Method": "GET"}},
 		InjectionLocation: methodwebtest.InjectionLocationHeader,
 		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventOptionsbleed),
+		FollowRedirects:   false,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/apache/path/modfile.go
+++ b/internal/apache/path/modfile.go
@@ -12,7 +12,7 @@ var commandInjectionPayloads = []string{
 	"; cat /etc/passwd",
 	"| cat /etc/hosts",
 	"&& ls -la",
-	"; echo 'vulnerable'",
+	"; echo 'RCE'",
 	"| echo 'RCE'",
 }
 
@@ -31,6 +31,22 @@ var commonModFilePaths = []string{
 	"/cgi-bin/printenv.cgi",
 }
 
+var queryParams = []string{
+	"action",   // frequently seen in forms and CGI
+	"mode",     // often used to toggle operations
+	"cmd",      // used in some admin/debug tools
+	"do",       // like ?do=login or ?do=edit
+	"option",   // generic control flag
+	"module",   // sometimes used in pluggable systems
+	"plugin",   // same as module
+	"function", // old PHP/Perl apps
+	"query",    // search/query handler
+	"search",   // common on older search pages
+	"type",     // selects file or action type
+	"lang",     // language, might be used for includes
+	"file",     // filename input
+}
+
 func PerformApachePathModFileInjection(ctx context.Context, config *methodwebtest.PathModFileConfig) *methodwebtest.Report {
 	generatedInjectionPayloads := generateModFileQueryInjectionParams(commandInjectionPayloads)
 
@@ -41,6 +57,7 @@ func PerformApachePathModFileInjection(ctx context.Context, config *methodwebtes
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: methodwebtest.InjectionLocationQuery,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventCommandecho),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,
@@ -54,8 +71,10 @@ func PerformApachePathModFileInjection(ctx context.Context, config *methodwebtes
 
 func generateModFileQueryInjectionParams(commandInjectionPayloads []string) []map[string]string {
 	payloads := []map[string]string{}
-	for _, payload := range commandInjectionPayloads {
-		payloads = append(payloads, map[string]string{"input": payload})
+	for _, queryParam := range queryParams {
+		for _, payload := range commandInjectionPayloads {
+			payloads = append(payloads, map[string]string{queryParam: payload})
+		}
 	}
 	return payloads
 }
@@ -63,11 +82,10 @@ func generateModFileQueryInjectionParams(commandInjectionPayloads []string) []ma
 func detectModFileRCE(report *methodwebtest.Report) {
 	// Deterministic detection function
 	indicators := []string{
-		"root:x",     // Common content in /etc/passwd
-		"127.0.0.1",  // Common content in /etc/hosts
-		"vulnerable", // Custom echo
-		"RCE",        // Custom echo
-		"total",      // Common output of ls -la
+		"root:x",    // Common content in /etc/passwd
+		"127.0.0.1", // Common content in /etc/hosts
+		"RCE",       // Custom echo
+		"total",     // Common output of ls -la
 	}
 	for _, target := range report.Targets {
 		if target.Attempts == nil {

--- a/internal/general/header/misconfigured/cors.go
+++ b/internal/general/header/misconfigured/cors.go
@@ -15,11 +15,12 @@ func PerformHeaderMisconfigurationCORS(ctx context.Context, config *methodwebtes
 	}
 
 	headerMisconfigurationConfig := methodwebtest.HeaderMisconfigurationEngineConfig{
-		Targets:   config.Targets,
-		Method:    methodwebtest.HttpMethodGet,
-		Payloads:  targetHeaderPayloadsList,
-		EventType: methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventCors),
-		Timeout:   config.Timeout,
+		Targets:         config.Targets,
+		Method:          methodwebtest.HttpMethodGet,
+		Payloads:        targetHeaderPayloadsList,
+		EventType:       methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventCors),
+		FollowRedirects: false,
+		Timeout:         config.Timeout,
 	}
 
 	report := utils.RunHeaderMisconfigurationEngine(ctx, &headerMisconfigurationConfig)
@@ -29,6 +30,9 @@ func PerformHeaderMisconfigurationCORS(ctx context.Context, config *methodwebtes
 
 func generateCORSHeaders(target string) []map[string]string {
 	return []map[string]string{
+		// Empty Request
+		{"": ""},
+
 		// Malicious origin with a spoofed referer.
 		// Positive hit: The server treats the request from `malicious-site.com` as if it came
 		// from `trusted-site.com`, allowing access.

--- a/internal/general/header/misconfigured/escape.go
+++ b/internal/general/header/misconfigured/escape.go
@@ -15,11 +15,12 @@ func PerformHeaderMisconfigurationEscape(ctx context.Context, config *methodwebt
 	}
 
 	headerMisconfigurationConfig := methodwebtest.HeaderMisconfigurationEngineConfig{
-		Targets:   config.Targets,
-		Method:    methodwebtest.HttpMethodGet,
-		Payloads:  targetHeaderPayloadsList,
-		EventType: methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventEscape),
-		Timeout:   config.Timeout,
+		Targets:         config.Targets,
+		Method:          methodwebtest.HttpMethodGet,
+		Payloads:        targetHeaderPayloadsList,
+		EventType:       methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventEscape),
+		FollowRedirects: false,
+		Timeout:         config.Timeout,
 	}
 
 	report := utils.RunHeaderMisconfigurationEngine(ctx, &headerMisconfigurationConfig)

--- a/internal/general/header/misconfigured/http.go
+++ b/internal/general/header/misconfigured/http.go
@@ -15,11 +15,12 @@ func PerformHeaderMisconfigurationHTTP(ctx context.Context, config *methodwebtes
 	}
 
 	headerMisconfigurationConfig := methodwebtest.HeaderMisconfigurationEngineConfig{
-		Targets:   config.Targets,
-		Method:    methodwebtest.HttpMethodOptions,
-		Payloads:  targetHeaderPayloadsList,
-		EventType: methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventHttp),
-		Timeout:   config.Timeout,
+		Targets:         config.Targets,
+		Method:          methodwebtest.HttpMethodOptions,
+		Payloads:        targetHeaderPayloadsList,
+		EventType:       methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventHttp),
+		FollowRedirects: false,
+		Timeout:         config.Timeout,
 	}
 
 	report := utils.RunHeaderMisconfigurationEngine(ctx, &headerMisconfigurationConfig)
@@ -29,6 +30,9 @@ func PerformHeaderMisconfigurationHTTP(ctx context.Context, config *methodwebtes
 
 func generateHTTPHeaders(target string) []map[string]string {
 	return []map[string]string{
+		// Empty Options request
+		{"": ""},
+
 		// Overly permissive HTTP methods.
 		// Positive hit: The server allows `TRACE` and `TRACK` methods, which can enable dangerous actions
 		// like Cross-Site Tracing (XST).

--- a/internal/general/header/misconfigured/sensitiveexposed.go
+++ b/internal/general/header/misconfigured/sensitiveexposed.go
@@ -14,11 +14,12 @@ func PerformHeaderMisconfigurationSensitiveExposed(ctx context.Context, config *
 	}
 
 	headerMisconfigurationConfig := methodwebtest.HeaderMisconfigurationEngineConfig{
-		Targets:   config.Targets,
-		Method:    methodwebtest.HttpMethodGet,
-		Payloads:  targetHeaderPayloadsList,
-		EventType: methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventSensitiveexposed),
-		Timeout:   config.Timeout,
+		Targets:         config.Targets,
+		Method:          methodwebtest.HttpMethodGet,
+		Payloads:        targetHeaderPayloadsList,
+		EventType:       methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventSensitiveexposed),
+		FollowRedirects: false,
+		Timeout:         config.Timeout,
 	}
 
 	report := utils.RunHeaderMisconfigurationEngine(ctx, &headerMisconfigurationConfig)
@@ -27,6 +28,9 @@ func PerformHeaderMisconfigurationSensitiveExposed(ctx context.Context, config *
 
 func generateSensitiveExposedHeaders(target string) []map[string]string {
 	return []map[string]string{
+		// Empty Request
+		{"": ""},
+
 		// Exposing sensitive headers to all origins.
 		// Positive hit: The server allows `Authorization` and `Set-Cookie` headers to be
 		// accessed by all origins, exposing credentials.

--- a/internal/general/header/serveroverload.go
+++ b/internal/general/header/serveroverload.go
@@ -19,6 +19,7 @@ func PerformHeaderServerOverloadInjection(ctx context.Context, config *methodweb
 		InjectedPayloads:  generatedPayloads,
 		InjectionLocation: methodwebtest.InjectionLocationHeader,
 		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventServeroverload),
+		FollowRedirects:   false,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/header/useragent.go
+++ b/internal/general/header/useragent.go
@@ -15,6 +15,7 @@ func PerformHeaderUserAgentInjection(ctx context.Context, config *methodwebtest.
 		InjectedPayloads:  []map[string]string{{"User-Agent": config.AgentHeader}},
 		InjectionLocation: methodwebtest.InjectionLocationHeader,
 		EventType:         methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventUseragent),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/command/echo.go
+++ b/internal/general/multi/command/echo.go
@@ -27,6 +27,7 @@ func PerformCommandEchoInjection(ctx context.Context, config *methodwebtest.Mult
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventCommandecho),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/command/timedelay.go
+++ b/internal/general/multi/command/timedelay.go
@@ -27,6 +27,7 @@ func PerformCommandTimeDelayInjection(ctx context.Context, config *methodwebtest
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventCommandtimedelay),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/sqli/boolean.go
+++ b/internal/general/multi/sqli/boolean.go
@@ -27,6 +27,7 @@ func PerformSqliBooleanInjection(ctx context.Context, config *methodwebtest.Mult
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSqliboolean),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/sqli/escape.go
+++ b/internal/general/multi/sqli/escape.go
@@ -44,6 +44,7 @@ func PerformSqliEscapeCharacterInjection(ctx context.Context, config *methodwebt
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSqliescape),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/sqli/timedelay.go
+++ b/internal/general/multi/sqli/timedelay.go
@@ -25,6 +25,7 @@ func PerformSQLiTimeDelayInjection(ctx context.Context, config *methodwebtest.Mu
 		InjectedPayloads:  generatedInjectionPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSqlitimedelay),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/general/multi/xss/alert.go
+++ b/internal/general/multi/xss/alert.go
@@ -40,6 +40,7 @@ func PerformXSSAlertInjection(ctx context.Context, config *methodwebtest.MultiIn
 		InjectedPayloads:  generatedPayloads,
 		InjectionLocation: config.InjectionLocation,
 		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventXssalert),
+		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/internal/nginx/header/bufferoverflowcontent.go
+++ b/internal/nginx/header/bufferoverflowcontent.go
@@ -43,7 +43,7 @@ func PerformNginxHeaderBufferOverflowInjection(ctx context.Context, config *meth
 			methodwebtest.HttpMethodPost,
 			methodwebtest.RequestParams{HeaderParams: headerParams, BodyParams: bodyParams},
 			[]*methodwebtest.EventType{methodwebtest.NewEventTypeFromHeaderEvent(methodwebtest.HeaderEventServeroverload)},
-			config.Timeout, true)
+			config.Timeout, false)
 		endTime := time.Now()
 
 		// Marshal data

--- a/internal/nginx/query/reverseproxy.go
+++ b/internal/nginx/query/reverseproxy.go
@@ -17,6 +17,7 @@ func PerformQueryReverseProxyInjection(ctx context.Context, config *methodwebtes
 		InjectedPayloads:  generateReverseProxyQueryInjectionParams(config.RedirectAddress),
 		InjectionLocation: methodwebtest.InjectionLocationQuery,
 		EventType:         methodwebtest.NewEventTypeFromQueryEvent(methodwebtest.QueryEventRedirect),
+		FollowRedirects:   false,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
 		Sleep:             config.Sleep,

--- a/utils/engines/headerMisconfigured.go
+++ b/utils/engines/headerMisconfigured.go
@@ -27,12 +27,19 @@ func RunHeaderMisconfigurationEngine(ctx context.Context, config *methodwebtest.
 			for retry := 0; retry <= config.Retries; retry++ {
 				attempt := methodwebtest.AttemptInfo{}
 				startTime := time.Now()
+
+				requestParams := methodwebtest.RequestParams{}
+				if _, ok := headerGroup[""]; !ok {
+					requestParams = methodwebtest.RequestParams{HeaderParams: headerGroup}
+				}
+
 				request := utils.PerformRequestScan(baseURL,
 					parsedPath,
 					config.Method,
-					methodwebtest.RequestParams{HeaderParams: headerGroup},
+					requestParams,
 					[]*methodwebtest.EventType{config.EventType},
-					config.Timeout, true)
+					config.Timeout,
+					config.FollowRedirects)
 				endTime := time.Now()
 
 				attempt.TimeSent = startTime

--- a/utils/engines/multiInjections.go
+++ b/utils/engines/multiInjections.go
@@ -44,7 +44,7 @@ func RunMultiInjectionsEngine(ctx context.Context, config *methodwebtest.Injecti
 				}
 
 				startTime := time.Now()
-				request := utils.PerformRequestScan(baseURL, baseLinePath, config.Method, baselineRequestParams, []*methodwebtest.EventType{config.EventType}, config.Timeout, true)
+				request := utils.PerformRequestScan(baseURL, baseLinePath, config.Method, baselineRequestParams, []*methodwebtest.EventType{config.EventType}, config.Timeout, config.FollowRedirects)
 				endTime := time.Now()
 
 				baselineAttemptInfo.TimeSent = startTime
@@ -64,7 +64,7 @@ func RunMultiInjectionsEngine(ctx context.Context, config *methodwebtest.Injecti
 					}
 
 					startTime := time.Now()
-					request := utils.PerformRequestScan(baseURL, injectedPath, config.Method, requestParams, []*methodwebtest.EventType{config.EventType}, config.Timeout, true)
+					request := utils.PerformRequestScan(baseURL, injectedPath, config.Method, requestParams, []*methodwebtest.EventType{config.EventType}, config.Timeout, config.FollowRedirects)
 					endTime := time.Now()
 
 					attemptInfo.TimeSent = startTime


### PR DESCRIPTION
## Redirect Config Update

Updated/enabled configurable redirect handling for injection modules

## Why

Different security testing scenarios require different redirect behaviors:

Certain vulnerability assessments (e.g., XSS, SQLI) benefit from following redirects to observe full exploitation paths
Other tests (e.g., open redirect vulnerabilities) specifically need to capture and analyze the 302 response itself

## Other

* Added Empty payload for HTTP, CORS, and Sensitive Header modules
* Updated Query parameters to inject for Apache RCE Payloads