### PR TITLE
Basic SSTI Detection

### DIFF
--- a/cmd/general.go
+++ b/cmd/general.go
@@ -497,7 +497,7 @@ func (a *MethodWebTest) InitGeneralCommand() {
 	}
 
 	multiCmd.Flags().String("method", "", "The HTTP method to use for the request")
-	multiCmd.Flags().String("event", "", "The event to test: XSSALERT, SQLIBOOLEAN, SQLIESCAPE, SQLITIMEDELAY, SSTI")
+	multiCmd.Flags().String("event", "", "The event to test: XSSALERT, SQLIBOOLEAN, SQLIESCAPE, SQLITIMEDELAY, SSTIREFLECT")
 	multiCmd.Flags().String("variabledata", "", "Base64 encoded Json string of variable names and base values to add to injects")
 	multiCmd.Flags().String("injectionlocation", "", "The injection location to test: HEADER, PATH, QUERY, BODY, FORM, MULTIPART")
 

--- a/cmd/general.go
+++ b/cmd/general.go
@@ -497,7 +497,7 @@ func (a *MethodWebTest) InitGeneralCommand() {
 	}
 
 	multiCmd.Flags().String("method", "", "The HTTP method to use for the request")
-	multiCmd.Flags().String("event", "", "The event to test: XSSALERT, SQLIBOOLEAN, SQLIESCAPE, SQLITIMEDELAY")
+	multiCmd.Flags().String("event", "", "The event to test: XSSALERT, SQLIBOOLEAN, SQLIESCAPE, SQLITIMEDELAY, SSTI")
 	multiCmd.Flags().String("variabledata", "", "Base64 encoded Json string of variable names and base values to add to injects")
 	multiCmd.Flags().String("injectionlocation", "", "The injection location to test: HEADER, PATH, QUERY, BODY, FORM, MULTIPART")
 

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -74,13 +74,3 @@ types:
       bodyParams: string
       formParams: map<string, string>
       multipartParams: map<string, string>
-  # Probe Structure
-  Probe:
-    properties:
-      payload: string
-      expectedResponse: optional<string>
-      expectedLatency: optional<integer>
-      engine: optional<string>
-      eventType: MultiEvent
-      injectionLocation: InjectionLocation
-      

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -39,6 +39,7 @@ types:
       - SQLIESCAPE
       - SQLITIMEDELAY
       - XSSALERT
+      - SSTI
   EventType:
     union:
       HeaderEvent: HeaderEvent
@@ -73,3 +74,13 @@ types:
       bodyParams: string
       formParams: map<string, string>
       multipartParams: map<string, string>
+  # Probe Structure
+  Probe:
+    properties:
+      payload: string
+      expectedResponse: optional<string>
+      expectedLatency: optional<integer>
+      engine: optional<string>
+      eventType: MultiEvent
+      injectionLocation: InjectionLocation
+      

--- a/fern/definition/request.yml
+++ b/fern/definition/request.yml
@@ -39,7 +39,7 @@ types:
       - SQLIESCAPE
       - SQLITIMEDELAY
       - XSSALERT
-      - SSTI
+      - SSTIREFLECT
   EventType:
     union:
       HeaderEvent: HeaderEvent

--- a/generated/go/request.go
+++ b/generated/go/request.go
@@ -5,6 +5,7 @@ package methodwebtest
 import (
 	json "encoding/json"
 	fmt "fmt"
+
 	internal "github.com/Method-Security/methodwebtest/generated/go/internal"
 )
 
@@ -366,6 +367,7 @@ const (
 	MultiEventSqliescape       MultiEvent = "SQLIESCAPE"
 	MultiEventSqlitimedelay    MultiEvent = "SQLITIMEDELAY"
 	MultiEventXssalert         MultiEvent = "XSSALERT"
+	MultiEventSsti             MultiEvent = "SSTI"
 )
 
 func NewMultiEventFromString(s string) (MultiEvent, error) {
@@ -382,6 +384,8 @@ func NewMultiEventFromString(s string) (MultiEvent, error) {
 		return MultiEventSqlitimedelay, nil
 	case "XSSALERT":
 		return MultiEventXssalert, nil
+	case "SSTI":
+		return MultiEventSsti, nil
 	}
 	var t MultiEvent
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/generated/go/request.go
+++ b/generated/go/request.go
@@ -366,7 +366,7 @@ const (
 	MultiEventSqliescape       MultiEvent = "SQLIESCAPE"
 	MultiEventSqlitimedelay    MultiEvent = "SQLITIMEDELAY"
 	MultiEventXssalert         MultiEvent = "XSSALERT"
-	MultiEventSsti             MultiEvent = "SSTI"
+	MultiEventSstireflect      MultiEvent = "SSTIREFLECT"
 )
 
 func NewMultiEventFromString(s string) (MultiEvent, error) {
@@ -383,8 +383,8 @@ func NewMultiEventFromString(s string) (MultiEvent, error) {
 		return MultiEventSqlitimedelay, nil
 	case "XSSALERT":
 		return MultiEventXssalert, nil
-	case "SSTI":
-		return MultiEventSsti, nil
+	case "SSTIREFLECT":
+		return MultiEventSstireflect, nil
 	}
 	var t MultiEvent
 	return "", fmt.Errorf("%s is not a valid %T", s, t)

--- a/generated/go/request.go
+++ b/generated/go/request.go
@@ -5,7 +5,6 @@ package methodwebtest
 import (
 	json "encoding/json"
 	fmt "fmt"
-
 	internal "github.com/Method-Security/methodwebtest/generated/go/internal"
 )
 

--- a/internal/general/multi/moduleSelector.go
+++ b/internal/general/multi/moduleSelector.go
@@ -29,8 +29,8 @@ func RunModuleSelector(ctx context.Context, config *methodwebtest.MultiInjection
 	if config.EventType == methodwebtest.MultiEventCommandecho {
 		return command.PerformCommandEchoInjection(ctx, config)
 	}
-	if config.EventType == methodwebtest.MultiEventSsti {
-		return ssti.PerformSSTIInjection(ctx, config)
+	if config.EventType == methodwebtest.MultiEventSstireflect {
+		return ssti.PerformSSTIReflectInjection(ctx, config)
 	}
 	return &methodwebtest.Report{Errors: []string{"No module found for event type"}}
 }

--- a/internal/general/multi/moduleSelector.go
+++ b/internal/general/multi/moduleSelector.go
@@ -6,6 +6,7 @@ import (
 	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
 	command "github.com/Method-Security/methodwebtest/internal/general/multi/command"
 	sqli "github.com/Method-Security/methodwebtest/internal/general/multi/sqli"
+	ssti "github.com/Method-Security/methodwebtest/internal/general/multi/ssti"
 	xss "github.com/Method-Security/methodwebtest/internal/general/multi/xss"
 )
 
@@ -27,6 +28,9 @@ func RunModuleSelector(ctx context.Context, config *methodwebtest.MultiInjection
 	}
 	if config.EventType == methodwebtest.MultiEventCommandecho {
 		return command.PerformCommandEchoInjection(ctx, config)
+	}
+	if config.EventType == methodwebtest.MultiEventSsti {
+		return ssti.PerformSSTIInjection(ctx, config)
 	}
 	return &methodwebtest.Report{Errors: []string{"No module found for event type"}}
 }

--- a/internal/general/multi/ssti/reflect.go
+++ b/internal/general/multi/ssti/reflect.go
@@ -16,7 +16,7 @@ var SSTIPayloads = []string{
 	"${{1337*42}}",
 }
 
-func PerformSSTIInjection(ctx context.Context, config *methodwebtest.MultiInjectionConfig) *methodwebtest.Report {
+func PerformSSTIReflectInjection(ctx context.Context, config *methodwebtest.MultiInjectionConfig) *methodwebtest.Report {
 	generatedPayloads := utils.GenerateInjectionPayloads(SSTIPayloads, config.VariableData)
 
 	injectionConfig := methodwebtest.InjectionEngineConfig{
@@ -25,7 +25,7 @@ func PerformSSTIInjection(ctx context.Context, config *methodwebtest.MultiInject
 		Paths:             []string{"/"},
 		InjectedPayloads:  generatedPayloads,
 		InjectionLocation: config.InjectionLocation,
-		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSsti),
+		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSstireflect),
 		FollowRedirects:   true,
 		Timeout:           config.Timeout,
 		Retries:           config.Retries,
@@ -33,11 +33,11 @@ func PerformSSTIInjection(ctx context.Context, config *methodwebtest.MultiInject
 	}
 
 	report := utils.RunMultiInjectionsEngine(ctx, &injectionConfig)
-	checkForSSTI(report)
+	checkForSSTIReflect(report)
 	return report
 }
 
-func checkForSSTI(report *methodwebtest.Report) {
+func checkForSSTIReflect(report *methodwebtest.Report) {
 	for _, target := range report.Targets {
 		if target.Attempts == nil {
 			continue

--- a/internal/general/multi/ssti/ssti.go
+++ b/internal/general/multi/ssti/ssti.go
@@ -1,0 +1,63 @@
+package general
+
+import (
+	"context"
+	"strings"
+
+	methodwebtest "github.com/Method-Security/methodwebtest/generated/go"
+	utils "github.com/Method-Security/methodwebtest/utils/engines"
+)
+
+var SSTIPayloads = []string{
+	"${7*7}",
+	"{{7*7}}",
+	"<%= 7 * 7 %>",
+	"#{ 7 * 7 }",
+	"${{7*7}}",
+}
+
+func PerformSSTIInjection(ctx context.Context, config *methodwebtest.MultiInjectionConfig) *methodwebtest.Report {
+	generatedPayloads := utils.GenerateInjectionPayloads(SSTIPayloads, config.VariableData)
+
+	injectionConfig := methodwebtest.InjectionEngineConfig{
+		Targets:           config.Targets,
+		Method:            config.Method,
+		Paths:             []string{"/"},
+		InjectedPayloads:  generatedPayloads,
+		InjectionLocation: config.InjectionLocation,
+		EventType:         methodwebtest.NewEventTypeFromMultiEvent(methodwebtest.MultiEventSsti),
+		FollowRedirects:   true,
+		Timeout:           config.Timeout,
+		Retries:           config.Retries,
+		Sleep:             config.Sleep,
+	}
+
+	report := utils.RunMultiInjectionsEngine(ctx, &injectionConfig)
+	checkForSSTI(report)
+	return report
+}
+
+func checkForSSTI(report *methodwebtest.Report) {
+	for _, target := range report.Targets {
+		if target.Attempts == nil {
+			continue
+		}
+		for _, attempt := range target.Attempts {
+			if attempt.Request == nil || attempt.Request.ResponseBody == nil {
+				continue
+			}
+			finding := false
+			if strings.Contains(*attempt.Request.ResponseBody, "49") {
+				finding = true
+			}
+			if !finding && attempt.Request.ResponseHeaders != nil {
+				for _, headerValue := range attempt.Request.ResponseHeaders {
+					if strings.Contains(headerValue, "49") {
+						finding = true
+					}
+				}
+			}
+			attempt.Finding = &finding
+		}
+	}
+}

--- a/internal/general/multi/ssti/ssti.go
+++ b/internal/general/multi/ssti/ssti.go
@@ -9,11 +9,11 @@ import (
 )
 
 var SSTIPayloads = []string{
-	"${7*7}",
-	"{{7*7}}",
-	"<%= 7 * 7 %>",
-	"#{ 7 * 7 }",
-	"${{7*7}}",
+	"${1337*42}",
+	"{{1337*42}}",
+	"<%= 1337 * 42 %>",
+	"#{ 1337 * 42 }",
+	"${{1337*42}}",
 }
 
 func PerformSSTIInjection(ctx context.Context, config *methodwebtest.MultiInjectionConfig) *methodwebtest.Report {
@@ -47,12 +47,12 @@ func checkForSSTI(report *methodwebtest.Report) {
 				continue
 			}
 			finding := false
-			if strings.Contains(*attempt.Request.ResponseBody, "49") {
+			if strings.Contains(*attempt.Request.ResponseBody, "56154") {
 				finding = true
 			}
 			if !finding && attempt.Request.ResponseHeaders != nil {
 				for _, headerValue := range attempt.Request.ResponseHeaders {
-					if strings.Contains(headerValue, "49") {
+					if strings.Contains(headerValue, "56154") {
 						finding = true
 					}
 				}


### PR DESCRIPTION
This PR adds basic SSTI (server-side template injection) capabilities to methodwebtest. This tool succeeded in finding an SSTI vulnerability on PortSwigger Web Security Academy vulnerable labs (https://portswigger.net/web-security/server-side-template-injection/exploiting/lab-server-side-template-injection-basic)

```
$ methodwebtest general multi -h
Perform injection tests in the multiple locations of a target

Usage:
  methodwebtest general multi [flags]

Flags:
      --event string               The event to test: XSSALERT, SQLIBOOLEAN, SQLIESCAPE, SQLITIMEDELAY, SSTI
  -h, --help                       help for multi
      --injectionlocation string   The injection location to test: HEADER, PATH, QUERY, BODY, FORM, MULTIPART
      --method string              The HTTP method to use for the request
      --variabledata string        Base64 encoded Json string of variable names and base values to add to injects

Global Flags:
  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
  -f, --output-file string   Path to output file. If blank, will output to STDOUT
  -q, --quiet                Suppress output
      --retries int          Number of attempts per credential pair
      --sleep int            Sleep time between requests (seconds)
      --targets strings      The URL of target
      --timeout int          Timeout per request (seconds) (default 30)
  -v, --verbose              Verbose output
```

Sample command (replace target instance with fresh lab):
```
$ methodwebtest general multi --event SSTI --injectionlocation QUERY --method GET --variabledata eyJtZXNzYWdlIjoiIn0K --targets "https://0afb00b804495ae880ae0822008f0050.web-security-academy.net/"
```